### PR TITLE
ci(frontend): add frontend-security workflow to master

### DIFF
--- a/.github/workflows/frontend-security.yml
+++ b/.github/workflows/frontend-security.yml
@@ -1,0 +1,44 @@
+---
+name: Frontend Security
+
+on:
+  pull_request:
+    branches: ["master"]
+    paths: ["frontend/**"]
+  schedule:
+    - cron: '0 9 * * 1,4'  # Every Monday and Thursday at 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+
+  socket-scan:
+    name: Socket supply-chain scan
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: socket-security/socket-security-action@v2
+        with:
+          api-key: ${{ secrets.ACTIONS_SOCKET_SCAN }}
+          working-directory: frontend
+...


### PR DESCRIPTION
## Summary

- Adds `frontend-security.yml` to the default branch so `workflow_dispatch` becomes available in the GitHub Actions UI
- Enables manual Socket supply-chain scan via **Actions → Frontend Security → Run workflow**
- Dependency review runs on PRs touching `frontend/**`; Socket scan runs on schedule (Mon/Thu) and manually

## Test plan

- [ ] After merge: open **Actions → Frontend Security** and verify the **Run workflow** button appears
- [ ] Trigger manually on `master` and confirm Socket scan completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)