### PR TITLE
ci(frontend): fix Socket action name to SocketDev/action@v1

### DIFF
--- a/.github/workflows/frontend-security.yml
+++ b/.github/workflows/frontend-security.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: socket-security/socket-security-action@v2
+      - uses: SocketDev/action@v1
         with:
           api-key: ${{ secrets.ACTIONS_SOCKET_SCAN }}
           working-directory: frontend


### PR DESCRIPTION
## Summary

- \`socket-security/socket-security-action\` не існує на GitHub
- Правильний репозиторій: \`SocketDev/action\` (latest: v1.3.2)

## Test plan

- [ ] Після мержу: **Actions → Frontend Security → Run workflow** → скан завершується без помилки "repository not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)