### PR TITLE
ci(frontend): fix SocketDev/action input names

### DIFF
--- a/.github/workflows/frontend-security.yml
+++ b/.github/workflows/frontend-security.yml
@@ -39,6 +39,6 @@ jobs:
 
       - uses: SocketDev/action@v1
         with:
-          api-key: ${{ secrets.ACTIONS_SOCKET_SCAN }}
-          working-directory: frontend
+          socket-token: ${{ secrets.ACTIONS_SOCKET_SCAN }}
+          patch-cwd: frontend
 ...


### PR DESCRIPTION
## Summary

- `api-key` → `socket-token`
- `working-directory` → `patch-cwd`

Valid inputs per `SocketDev/action@v1` schema (visible in the workflow run warning).

## Test plan

- [ ] After merge: trigger **Actions → Frontend Security → Run workflow** and confirm no "Unexpected input" warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)