### PR TITLE
ci(frontend): fix Socket scan — add mode and sfw npm ci step

### DIFF
--- a/.github/workflows/frontend-security.yml
+++ b/.github/workflows/frontend-security.yml
@@ -37,8 +37,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
       - uses: SocketDev/action@v1
         with:
+          mode: firewall-enterprise
           socket-token: ${{ secrets.ACTIONS_SOCKET_SCAN }}
-          patch-cwd: frontend
+
+      - run: sfw npm ci
+        working-directory: frontend
 ...


### PR DESCRIPTION
## Summary

`SocketDev/action` — это не standalone-сканер, а firewall-обёртка для пакетного менеджера.

Правильный способ использования:
1. Установить action с `mode: firewall-enterprise`
2. Запустить `sfw npm ci` вместо `npm ci`

Изменения:
- Добавлен `mode: firewall-enterprise`
- Добавлен шаг `setup-node` с кешированием
- `sfw npm ci` в `frontend/`
- Убран `patch-cwd` (не нужен при этом подходе)

## Test plan

- [ ] После мержа: запустить **Actions → Frontend Security → Run workflow** и убедиться что скан проходит без ошибок

🤖 Generated with [Claude Code](https://claude.com/claude-code)