### PR TITLE
ci(frontend): pass SOCKET_API_KEY env to sfw npm ci step

### DIFF
--- a/.github/workflows/frontend-security.yml
+++ b/.github/workflows/frontend-security.yml
@@ -50,4 +50,6 @@ jobs:
 
       - run: sfw npm ci
         working-directory: frontend
+        env:
+          SOCKET_API_KEY: ${{ secrets.ACTIONS_SOCKET_SCAN }}
 ...


### PR DESCRIPTION
## Summary

\`SocketDev/action\` installs the \`sfw\` binary but does not export the token to subsequent steps' environment. \`sfw\` looks for \`SOCKET_API_KEY\` — passing it explicitly via \`env:\`.

## Test plan

- [ ] After merge: **Actions → Frontend Security → Run workflow** — scan completes without \`SOCKET_API_KEY must be a valid API key\` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)