### PR TITLE
ci(frontend): add environment: production to socket-scan job

### DIFF
--- a/.github/workflows/frontend-security.yml
+++ b/.github/workflows/frontend-security.yml
@@ -31,6 +31,7 @@ jobs:
     name: Socket supply-chain scan
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

\`ACTIONS_SOCKET_SCAN\` is stored as a **production environment secret**, not a repository secret. Without \`environment: production\` on the job, GitHub does not expose it — causing the empty \`SOCKET_API_KEY\`.

## Test plan

- [ ] After merge: **Actions → Frontend Security → Run workflow** — \`SOCKET_API_KEY\` is non-empty and scan completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)