### PR TITLE
ci(frontend): use ci environment for socket scan job

### DIFF
--- a/.github/workflows/frontend-security.yml
+++ b/.github/workflows/frontend-security.yml
@@ -31,7 +31,7 @@ jobs:
     name: Socket supply-chain scan
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    environment: production
+    environment: ci
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

Replaces \`environment: production\` with \`environment: ci\` on the \`socket-scan\` job.

\`production\` has branch protection rules that block \`workflow_dispatch\` from non-master branches. The \`ci\` environment has no such restrictions and holds \`ACTIONS_SOCKET_SCAN\`.

## Test plan

- [ ] After merge: trigger **Actions → Frontend Security → Run workflow** from any branch — scan completes without environment protection error

🤖 Generated with [Claude Code](https://claude.com/claude-code)