### PR TITLE
ci(frontend): switch Socket scan to firewall-free mode

### DIFF
--- a/.github/workflows/frontend-security.yml
+++ b/.github/workflows/frontend-security.yml
@@ -31,10 +31,8 @@ jobs:
     name: Socket supply-chain scan
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    environment: ci
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 
@@ -46,11 +44,8 @@ jobs:
 
       - uses: SocketDev/action@v1
         with:
-          mode: firewall-enterprise
-          socket-token: ${{ secrets.ACTIONS_SOCKET_SCAN }}
+          mode: firewall-free
 
       - run: sfw npm ci
         working-directory: frontend
-        env:
-          SOCKET_API_KEY: ${{ secrets.ACTIONS_SOCKET_SCAN }}
 ...


### PR DESCRIPTION
## Summary

\`firewall-enterprise\` requires a paid Socket.dev subscription — API returns 403 "Error while identifying active SKUs".

Switching to \`firewall-free\`:
- No API key or subscription required
- Still intercepts supply-chain attacks during \`npm ci\`
- Removes \`environment: ci\`, \`socket-token\`, and \`SOCKET_API_KEY\` env var

## Test plan

- [ ] After merge: **Actions → Frontend Security → Run workflow** — \`sfw npm ci\` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)