### PR TITLE
ci(frontend): remove npm cache from socket-scan setup-node

### DIFF
--- a/.github/workflows/frontend-security.yml
+++ b/.github/workflows/frontend-security.yml
@@ -39,8 +39,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
 
       - uses: SocketDev/action@v1
         with:


### PR DESCRIPTION
## Summary

\`setup-node\` with \`cache: npm\` fails because \`/home/runner/.npm\` is empty — \`sfw npm ci\` hasn't run yet at that point. Caching is not needed for a security scan.

## Test plan

- [ ] After merge: **Actions → Frontend Security → Run workflow** — setup-node completes without cache error

🤖 Generated with [Claude Code](https://claude.com/claude-code)