### PR TITLE
ci(deploy): fix INFISICAL_API_URL read from secrets not vars [skip deploy]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run deploy
         working-directory: ansible
         env:
-          INFISICAL_API_URL: ${{ vars.INFISICAL_API_URL }}
+          INFISICAL_API_URL: ${{ secrets.INFISICAL_API_URL }}
           INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
           INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
         run: ansible-playbook -i inventories/zelgray.work -vv playbooks/deploy.yml


### PR DESCRIPTION
## Summary

`INFISICAL_API_URL` was added to the production environment as a **secret**, but `deploy.yml` was reading it from `vars.INFISICAL_API_URL` (GitHub Variables). This caused an empty URL and Infisical login failure.

**Change:** `${{ vars.INFISICAL_API_URL }}` → `${{ secrets.INFISICAL_API_URL }}`

## Test plan

- [ ] After merge: push a change to master and confirm deploy reaches Infisical login without "No scheme supplied" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)