### PR TITLE
fix(ci): replace COPY --if-exists with mkdir -p in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,9 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
+      - name: Ensure frontend directory exists
+        run: mkdir -p frontend
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-# syntax=docker/dockerfile:1.7
-
 # Stage 1: Build frontend (skipped if frontend/package.json is absent)
 FROM node:22-alpine AS frontend-builder
 WORKDIR /app
-COPY --if-exists frontend/ ./
+COPY frontend/ ./
 RUN if [ -f package.json ]; then npm ci; fi
 ARG VITE_DISCORD_CLIENT_ID
 RUN if [ -f package.json ]; then npm run build; else mkdir -p dist; fi


### PR DESCRIPTION
## Summary

- Remove `COPY --if-exists` from Dockerfile (requires experimental `dockerfile:1.7-labs`, not available in stable BuildKit)
- Add `mkdir -p frontend` step in `build.yml` before Docker build to ensure the directory exists on branches without frontend source
- Remove `# syntax=docker/dockerfile:1.7` directive (no longer needed)