### PR TITLE
fix(ci): move matrix.environment filter from job if to step if [skip deploy]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
   workflow_run:
     workflows: ["Build"]
     types: [completed]
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
     inputs:
       sha:
@@ -34,8 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ matrix.environment }}
     if: >-
-      (github.event_name == 'workflow_dispatch' &&
-        (inputs.environment == '' || inputs.environment == matrix.environment)) ||
+      github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     strategy:
       matrix:
@@ -46,6 +45,8 @@ jobs:
             environment: development
     steps:
       - name: Send repository dispatch to infra
+        if: >-
+          inputs.environment == '' || inputs.environment == matrix.environment
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,9 +3,9 @@ name: Lint
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,9 @@ name: Test
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- \`matrix\` context is not available in job-level \`if\` expressions — GitHub Actions evaluates them before matrix expansion, causing the \"Unrecognized named-value: 'matrix'\" parse error
- Moved the environment filter from the job \`if\` to the step \`if\`, where \`matrix\` context is valid
- Fixed \`workflow_run\` branches filter: \`master\` → \`main\`

## Test plan
- [x] Workflow file parses without errors after merge
- [x] Manual dispatch with specific environment triggers only the matching matrix job's step
- [x] Manual dispatch with empty environment triggers both steps
- [x] Auto-trigger on Build success triggers both steps