### PR TITLE
ci: restrict auto build/deploy to production only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,17 @@ on:
     types: [completed]
     branches: [main]
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to build'
+        required: true
+        type: choice
+        options:
+          - production
+          - development
+      ref:
+        description: 'Branch or SHA to build from (development only)'
+        required: false
 
 concurrency:
   group: build
@@ -40,18 +51,14 @@ jobs:
               core.setFailed(`${actor} does not have write access — build blocked`);
             }
 
-  build:
-    name: Build and push (${{ matrix.env }})
+  build-prod:
+    name: Build and push (prod)
     needs: verify
     runs-on: ubuntu-latest
-    environment: ${{ matrix.environment }}
-    strategy:
-      matrix:
-        include:
-          - env: prod
-            environment: production
-          - env: dev
-            environment: development
+    environment: production
+    if: >-
+      github.event_name == 'workflow_run' ||
+      (github.event_name == 'workflow_dispatch' && inputs.environment == 'production')
     steps:
       - uses: actions/checkout@v4
         with:
@@ -73,8 +80,40 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/discord-meow-bot:${{ matrix.env }}-${{ github.event.workflow_run.head_sha || github.sha }}
-            ghcr.io/${{ github.repository_owner }}/discord-meow-bot:${{ matrix.env }}-latest
+            ghcr.io/${{ github.repository_owner }}/discord-meow-bot:prod-${{ github.event.workflow_run.head_sha || github.sha }}
+            ghcr.io/${{ github.repository_owner }}/discord-meow-bot:prod-latest
+          build-args: |
+            VITE_DISCORD_CLIENT_ID=${{ secrets.VITE_DISCORD_CLIENT_ID }}
+
+  build-dev:
+    name: Build and push (dev)
+    needs: verify
+    runs-on: ubuntu-latest
+    environment: development
+    if: >-
+      github.event_name == 'workflow_dispatch' && inputs.environment == 'development'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure frontend directory exists
+        run: mkdir -p frontend
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/discord-meow-bot:dev-latest
           build-args: |
             VITE_DISCORD_CLIENT_ID=${{ secrets.VITE_DISCORD_CLIENT_ID }}
 ...

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,8 @@ jobs:
     steps:
       - name: Send repository dispatch to infra
         if: >-
-          inputs.environment == '' || inputs.environment == matrix.environment
+          (github.event_name == 'workflow_run' && matrix.environment == 'production') ||
+          (github.event_name == 'workflow_dispatch' && (inputs.environment == '' || inputs.environment == matrix.environment))
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.DEPLOY_TOKEN }}


### PR DESCRIPTION
## Summary

- **Auto (merge to main)**: build only `prod` image, deploy only to `production`
- **Manual dispatch (build)**: choose `production` or `development`; dev builds accept an optional `ref` (branch/SHA) to build from any branch
- **Manual dispatch (deploy)**: unchanged — choose environment or leave empty for both

## Changes

**build.yml**: replaced matrix with two separate jobs (`build-prod`, `build-dev`)
- `build-prod`: runs on `workflow_run` (auto) + `workflow_dispatch` with `environment=production`
- `build-dev`: runs only on `workflow_dispatch` with `environment=development`, uses `inputs.ref` for checkout

**deploy.yml**: changed step-level `if` condition
- `workflow_run`: only dispatches to production
- `workflow_dispatch`: respects `inputs.environment` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)